### PR TITLE
L: add psycho (1960) to classics

### DIFF
--- a/classics.csv
+++ b/classics.csv
@@ -6,3 +6,4 @@ The Breakfast Club, John Hughes, 1985
 Monty Python and the Holy Grail, Terry Gilliam, 1975
 The Curious Case of Benjamin Button, David Fincher, 2008
 Willow, Ron Howard, 1988
+Psycho, Alfred Hitchcock, 1960


### PR DESCRIPTION
Psycho is indisputable a landmark in horror cinema, enduring in its legacy and a riveting watch to this day. It deserves to be added.